### PR TITLE
Add 3-way radiobutton to allow action choice on fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ work
 .classpath
 .project
 .settings
+.idea/
+preSCMbuildstep.iml

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532</version>
+    <version>1.580</version>
   </parent>
 
   <artifactId>preSCMbuildstep</artifactId>
   <packaging>hpi</packaging>
   <name>Pre SCM BuildStep Plugin</name>
-  <version>0.4-SNAPSHOT</version>
+  <version>0.4</version>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/pre-scm-buildstep</url>
 
   <developers>
@@ -41,8 +41,8 @@
   </build>
   <repositories>
     <repository>
-      <id>maven.jenkins-ci.org</id>
-      <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 

--- a/src/main/resources/org/jenkinsci/plugins/preSCMbuildstep/PreSCMBuildStepsWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/preSCMbuildstep/PreSCMBuildStepsWrapper/config.jelly
@@ -29,7 +29,26 @@
                  descriptors="${h.getBuilderDescriptors(it)}"
                  items="${instance.buildSteps}"
                  addCaption="${%Add build step}"/>
-            <f:checkbox field="failOnError" title="Fail the build on error"/>
         </div>
+        </f:nested>
+        <f:nested>
+            <table>
+                <f:entry title="Action on pre-build failure:">
+                    <st:nbsp /><st:nbsp />
+                    <f:radio name="actionOnError"
+                             checked="${instance.actionOnError == null || instance.actionOnError == 'continue'}" value="continue"/>
+                    <label class="attach-previous">Continue to build steps</label>
+
+                    <st:nbsp /><st:nbsp />
+                    <f:radio name="actionOnError"
+                             checked="${instance.actionOnError == 'fail'}" value="fail"/>
+                    <label class="attach-previous">Fail build</label>
+
+                    <st:nbsp /><st:nbsp />
+                    <f:radio name="actionOnError"
+                             checked="${instance.actionOnError == 'terminate'}" value="terminate"/>
+                    <label class="attach-previous">Terminate build</label>
+                </f:entry>
+            </table>
         </f:nested>
 </j:jelly>


### PR DESCRIPTION
In this change request I suggest to add a 3-way button to set the action on
pre-build failure:

continue  - ignore errors and continue to build steps
fail      - stop build and mark it as failure
terminate - stop build and mark it as not built

The idea is to check the build request and abort the run even before fetching
from scm in case there is no need to build.
