### PR TITLE
Require Jenkins 2.387.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <!-- atypical gitHubRepo value due to artifactId -->
     <gitHubRepo>jenkinsci/pre-scm-buildstep-plugin</gitHubRepo>
-    <jenkins.version>2.375.4</jenkins.version>
+    <jenkins.version>2.387.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>


### PR DESCRIPTION
## "Require Jenkins 2.387.3 or newer

Require Jenkins 2.387.3 or newer so that users don't misunderstand the versions that I'm testing.

### Testing done

Confirmed that Jenkins 2.411 works as expected with this version of the plugin.  Tested a pre-scm step that lists the working directory and then confirmed that a following step that cloned a repository was behaving as expected.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
