### PR TITLE
Enable spotless again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </developer>
   </developers>
 
-  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+  <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <tag>${scmTag}</tag>
@@ -54,8 +54,7 @@
     <jenkins.version>2.387.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
-    <!-- TODO: Enable spotless when Java 21 issue is fixed -->
-    <!-- <spotless.check.skip>false</spotless.check.skip> -->
+    <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
   <repositories>


### PR DESCRIPTION
## Enable spotless again

Parent pom 4.72 is needed for spotless on Java 21.

Thanks @NotMyFault for detecting my issue!

Also simplifies the 'scm' tag because this is not a multi-module repository.

### Testing done

Confirmed that `mvn spotless:apply` works as expected on the pom.xml file and on Java files with Java 21 early access.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
