### PR TITLE
Require Jenkins 2.426.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,10 +51,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <!-- atypical gitHubRepo value due to artifactId -->
     <gitHubRepo>jenkinsci/pre-scm-buildstep-plugin</gitHubRepo>
-    <jenkins.version>2.387.3</jenkins.version>
-    <!-- TODO: Remove when plugin pom is using this version or newer -->
-    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
-    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
+    <jenkins.version>2.426.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>


### PR DESCRIPTION
## Require Jenkins 2.426.3 or newer

As of 19 Apr 2024, 61% of the installations of the most recent release (71.v1f2990a_37e27 - released a year ago) are using Jenkins 2.426.3 or newer.

Jenkins 2.426.3 is the first version with the fix for https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3314, the arbitrary file read vulnerability through the CLI can lead to RCE. It is a very good choice as a minimum Jenkins version.

Jenkins 2.426.3 is one of the versions suggested by https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/

Also removes a workaround for spotbugs version that is no longer required.

### Testing done

Used by jobs in my 2.440.3 installation with no errors reported.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
